### PR TITLE
alu-107061/new-test-cases

### DIFF
--- a/tests-twitter.js
+++ b/tests-twitter.js
@@ -179,6 +179,6 @@ test("getBestVideo", function(assert) {
   assert.equal(getBestVideo(fourVideosNegativeBitrates), 'https://video.twimg.com/video3.mp4', 'four_videos_negative_bitrates');
   assert.equal(getBestVideo(videosWithoutBitrate), 'https://video.twimg.com/video2.mp4', 'videos_without_bitrate');
   assert.equal(getBestVideo(threeMp4sMiddleMaxBitrate), 'https://video.twimg.com/video2.mp4', 'three_mp4s_middle_max_bitrate');
-  assert.equal(getBestVideo(noVideos), null, 'no_videos'); // Fails due to no checking if there is any video in the array
-  assert.equal(getBestVideo(noMp4s), null, 'no_mp4s'); // Fails due to no ckecing if there is any MP4 in the array
+  assert.equal(getBestVideo(noVideos), null, 'no_videos');
+  assert.equal(getBestVideo(noMp4s), null, 'no_mp4s');
 });

--- a/tests-twitter.js
+++ b/tests-twitter.js
@@ -173,7 +173,7 @@ noMp4s = [{
 test("getBestVideo", function(assert) {
   assert.equal(getBestVideo(oneMp4), 'https://video.twimg.com/video4.mp4', '4_videos_one_mp4_last_one');
   assert.equal(getBestVideo(twoMp4s), 'https://video.twimg.com/video5.mp4', '5_videos_two_mp4s_last_one');
-  assert.equal(getBestVideo(equalBitrates), 'https://video.twimg.com/video1.mp4', 'equal_bitrates_two_mp4s_last_one');
+  assert.equal(getBestVideo(equalBitrates), 'https://video.twimg.com/video1.mp4', 'equal_bitrates_two_mp4s_first_one');
   assert.equal(getBestVideo(twoVideosStringBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_string_bitrate');
   assert.equal(getBestVideo(twoVideosFloatBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_float_bitrate');
   assert.equal(getBestVideo(fourVideosNegativeBitrates), 'https://video.twimg.com/video3.mp4', 'four_videos_negative_bitrates');

--- a/tests-twitter.js
+++ b/tests-twitter.js
@@ -117,7 +117,7 @@ fourVideosNegativeBitrates = [{
 ];
 
 /* Test if the method works well with two MP4s given 
-   without bitrate information (first video expected). */
+   without bitrate information (last video expected). */
 videosWithoutBitrate = [{
   content_type: 'video/mp4',
   url: 'https://video.twimg.com/video1.mp4'
@@ -177,7 +177,7 @@ test("getBestVideo", function(assert) {
   assert.equal(getBestVideo(twoVideosStringBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_string_bitrate');
   assert.equal(getBestVideo(twoVideosFloatBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_float_bitrate');
   assert.equal(getBestVideo(fourVideosNegativeBitrates), 'https://video.twimg.com/video3.mp4', 'four_videos_negative_bitrates');
-  assert.equal(getBestVideo(videosWithoutBitrate), 'https://video.twimg.com/video1.mp4', 'videos_without_bitrate');
+  assert.equal(getBestVideo(videosWithoutBitrate), 'https://video.twimg.com/video2.mp4', 'videos_without_bitrate');
   assert.equal(getBestVideo(threeMp4sMiddleMaxBitrate), 'https://video.twimg.com/video2.mp4', 'three_mp4s_middle_max_bitrate');
   assert.equal(getBestVideo(noVideos), null, 'no_videos'); // Fails due to no checking if there is any video in the array
   assert.equal(getBestVideo(noMp4s), null, 'no_mp4s'); // Fails due to no ckecing if there is any MP4 in the array

--- a/tests-twitter.js
+++ b/tests-twitter.js
@@ -17,6 +17,168 @@ oneMp4 = [{
   }
 ];
 
+/* Test if the method works well with two MP4s given 
+   with different bitrates */
+twoMp4s = [{
+  content_type: 'application/x-mpegUrl',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  content_type: 'application/x-mpegURL',
+  url: 'https://video.twimg.com/video2.mp4'
+},
+{
+  content_type: 'application/x-mpegUrl',
+  url: 'https://video.twimg.com/video3.mp4'
+},
+{
+  bitrate: 2000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video4.mp4'
+},
+{
+  bitrate: 42000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video5.mp4'
+}
+];
+
+/* Test if the method works well with two MP4s given 
+   with equal bitrates (first video expected) */
+equalBitrates = [{
+  bitrate: 42000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  bitrate: 42000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+}
+];
+
+/* Test if the method works well with two MP4s given 
+   with different bitrates, and the highest bitrate 
+   as string, to check the behavior with other types
+   of data, different than integers. */
+twoVideosStringBitrate = [{
+  bitrate: 22000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  bitrate: "42000",
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+}
+];
+
+/* Test if the method works well with two MP4s given 
+   with different bitrates, and the highest bitrate 
+   as float, to check the behavior with other types
+   of data, different than integers. */
+twoVideosFloatBitrate = [{
+  bitrate: 22000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  bitrate: 43000.0,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+}
+];
+
+/* Test if the method works well with four MP4s given 
+   with different negative bitrates. Maybe this case
+   is not as common as the rest, but our application
+   should keep working even in that case, retrieving
+   the URL of the video with higest bitrate. */
+fourVideosNegativeBitrates = [{
+  bitrate: -22000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  bitrate: -43000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+},
+{
+  bitrate: -12000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video3.mp4'
+},
+{
+  bitrate: -42000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video4.mp4'
+}
+];
+
+/* Test if the method works well with two MP4s given 
+   without bitrate information (first video expected). */
+videosWithoutBitrate = [{
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+}
+];
+
+/* Test if the method works well with three MP4s given 
+   with different bitrates, having the maximum bitrate
+   in the second position. */
+threeMp4sMiddleMaxBitrate = [{
+  bitrate: 42000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  bitrate: 120000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video2.mp4'
+},
+{
+  bitrate: 4000,
+  content_type: 'video/mp4',
+  url: 'https://video.twimg.com/video3.mp4'
+}
+];
+
+/* Test if the method returns nothing when the array
+   does not contain videos. */
+noVideos = []
+
+/* Test if the method returns nothing when the array
+   does not contain MP4s. */
+noMp4s = [{
+  bitrate: 42000,
+  content_type: 'application/x-mpegUrl',
+  url: 'https://video.twimg.com/video1.mp4'
+},
+{
+  content_type: 'application/x-mpegURL',
+  url: 'https://video.twimg.com/video2.mp4'
+},
+{
+  content_type: 'application/x-mpegUrl',
+  bitrate: 12000,
+  url: 'https://video.twimg.com/video3.mp4'
+}
+];
+
 test("getBestVideo", function(assert) {
   assert.equal(getBestVideo(oneMp4), 'https://video.twimg.com/video4.mp4', '4_videos_one_mp4_last_one');
+  assert.equal(getBestVideo(twoMp4s), 'https://video.twimg.com/video5.mp4', '5_videos_two_mp4s_last_one');
+  assert.equal(getBestVideo(equalBitrates), 'https://video.twimg.com/video1.mp4', 'equal_bitrates_two_mp4s_last_one');
+  assert.equal(getBestVideo(twoVideosStringBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_string_bitrate');
+  assert.equal(getBestVideo(twoVideosFloatBitrate), 'https://video.twimg.com/video2.mp4', 'two_videos_float_bitrate');
+  assert.equal(getBestVideo(fourVideosNegativeBitrates), 'https://video.twimg.com/video3.mp4', 'four_videos_negative_bitrates');
+  assert.equal(getBestVideo(videosWithoutBitrate), 'https://video.twimg.com/video1.mp4', 'videos_without_bitrate');
+  assert.equal(getBestVideo(threeMp4sMiddleMaxBitrate), 'https://video.twimg.com/video2.mp4', 'three_mp4s_middle_max_bitrate');
+  assert.equal(getBestVideo(noVideos), null, 'no_videos'); // Fails due to no checking if there is any video in the array
+  assert.equal(getBestVideo(noMp4s), null, 'no_mp4s'); // Fails due to no ckecing if there is any MP4 in the array
 });


### PR DESCRIPTION
# Adding test cases for `getBestVideo()` method

With this set of test cases we are validating many of the possible situations that can occur for the method `getBestVideo()` that retrieves us the url of the MP4 video with highest bitrate from the array passed as argument.

We are testing the following situations:
- Four videos from where one is an MP4
- Five videos from where two are MP4s with different bitrates
- Two MP4 videos with the same bitrate (first one expected)
- Two MP4 videos with different bitrates, in different formats (string)
- Two MP4 videos with different bitrates, in different formats (float)
- Four MP4 videos with different (negative) bitrates
- Two MP4 videos without bitrate information (last one expected)
- Three MP4 videos, with different bitrates (second one has the highest)
- No videos in the array
- Three videos (no MP4s in the array)

Of course, it is just a simple test with 10 test cases selected to check the correct behavior of the method in special situations, but more would be required to get a trusted method, taking into account also other situations (like other content_types, no url on the video with highest bitrate, ...).

> Author: **Samuel Navarro Diez _(alu.107061)_**